### PR TITLE
Automatically Close & Lock Stale PRs/Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/stale@v8
+      with:
+        exempt-issue-assignees: 'alexander0042'
+        exempt-pr-assignees: 'alexander0042'
+        exempt-issue-labels: 'no-autoclose'
+        exempt-pr-labels: 'no-autoclose'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'There has been no activity on this issue for ninety days and unless you comment on the issue it will automatically close in seven days.'
+        stale-pr-message: 'There has been no activity on this pull request for ninety days and unless you comment on the pull request it will automatically close in seven days.'
+        close-issue-message: 'This issue was closed because it has been stalled for seven days with no activity.'
+        close-pr-message: 'This pull request was closed because it has been stalled for seven days with no activity.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 90
+        days-before-close: 7
+        enable-statistics: 'true'
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          issue-inactive-days: '30'
+          pr-inactive-days: '30'
+          issue-lock-reason: ''


### PR DESCRIPTION
As mentioned https://github.com/alexander0042/pirateweather/issues/33#issuecomment-1625583379 I went ahead and created a workflow which after ninety days posts a message about the issue/pull request being locked in seven days if there has been no activity. This message will not post for any items assigned to you or has the no-autoclose label on them.

I also added the workflow to lock closed issues/pull requests thirty days after being closed which prevents anyone but collaborators from commenting on the issue/pull request.