### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/apiable.yml
+++ b/.github/ISSUE_TEMPLATE/apiable.yml
@@ -1,0 +1,22 @@
+name: Apiable Issue
+description: Report an issue with APIable portal.
+labels: ["apiable" , "Needs Review"]
+body:
+
+  - type: textarea
+    id: describe-the-issue
+    attributes:
+      label: Describe the issue
+      description: Describe the issue with APIable.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I have searched this repository to see if the issue has already been reported.
+          required: true
+        - label: I have written an informative title.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/alexander0042/pirateweather/discussions
+    about: Please ask and answer questions here.
+  - name: Home Assistant Repository
+    url: https://github.com/alexander0042/pirate-weather-ha
+    about: Please report any issues with the Home Assistant integration here.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -17,7 +17,7 @@ body:
       label: Documentation URL
       description: A link to the section/page where the issue with the documentation is.
       placeholder: |
-        Example: "Ottawa, Ontario, Canada"
+        Example: "https://pirateweather.net/en/latest/API/"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,32 @@
+name: Documentation Issue
+description: Report an issue with the PirateWeather API documentation.
+labels: ["documentation" , "Needs Review"]
+body:
+
+  - type: textarea
+    id: describe-the-issue
+    attributes:
+      label: Describe the issue
+      description: Describe the issue with the API documentation
+    validations:
+      required: true
+      
+  - type: input
+    id: documentation-url
+    attributes:
+      label: Documentation URL
+      description: A link to the section/page where the issue with the documentation is.
+      placeholder: |
+        Example: "Ottawa, Ontario, Canada"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I have searched this repository to see if the issue has already been reported.
+          required: true
+        - label: I have written an informative title.
+          required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,21 @@
+name: Feature Request
+description: Request a feature to be added to the PirateWeather API
+labels: ["enhancement", "Needs Review"]
+body:
+
+  - type: textarea
+    id: describe-the-feature
+    attributes:
+      label: Describe the feature
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I have searched this repository and [Home Assistant Repository](https://github.com/alexander0042/pirate-weather-ha) to see if the feature has already been requested.
+          required: true
+        - label: I have written an informative title.
+          required: true

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,23 @@
+name: General Issue
+description: Report an general issue with the API.
+labels: ["Needs Review"]
+body:
+
+  - type: textarea
+    id: describe-the-issue
+    attributes:
+      label: Describe the issue
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I have searched this repository and [Home Assistant Repository](https://github.com/alexander0042/pirate-weather-ha) to see if the issue has already been reported.
+          required: true
+        - label: I have read through the [API documentation](https://pirateweather.net/en/latest/API/) before opening this issue.
+          required: true
+        - label: I have written an informative title.
+          required: true

--- a/.github/ISSUE_TEMPLATE/report_bug.yml
+++ b/.github/ISSUE_TEMPLATE/report_bug.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report an issue with the PirateWeather API.
+labels: ["bug" , "Needs Review"]
+body:
+
+  - type: textarea
+    id: describe-the-bug
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is and how to repoduce it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Explain what actually happens.
+      placeholder: |
+        Example:
+          "This happened instead..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api-endpoint
+    attributes:
+      label: API Endpoint
+      options: 
+        - TimeMachine
+        - Development
+        - Production
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: api-location
+    attributes:
+      label: Location
+      description: The location used in the API request.
+      placeholder: |
+        Example: "Ottawa, Ontario, Canada"
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other details
+      placeholder: |
+        Additional details and attachments.
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Troubleshooting steps
+      description: Before reporting an issue follow these troubleshooting steps to see if it solves the issue.
+      options:
+        - label: I have searched this repository and [Home Assistant Repository](https://github.com/alexander0042/pirate-weather-ha) to see if the issue has already been reported.
+          required: true
+        - label: I have read through the [API documentation](https://pirateweather.net/en/latest/API/) before opening this issue.
+          required: true
+        - label: I have written an informative title.
+          required: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,18 +19,18 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'There has been no activity on this issue in the last ninety days and will automatically close in seven days. Leave a comment on this issue to prevent it from closing automatically.'
         stale-pr-message: 'There has not been any activity on this pull request in the last ninety days and will automatically close in seven days. Leave a comment on this pull request to prevent it from closing automatically.'
-        close-issue-message: 'This issue has been automatically closed since there has been no further activity after seven days and will be automatically locked in sixty days. During that time feel free to re-open the issue or you can create a new follow-up issue afterwards.'
-        close-pr-message: 'This pull request has been automatically closed since there has been no further activity after seven days and will be automatically locked in sixty days. During that time feel free to re-open the pull request or you can create a new follow-up pull request afterwards.'
+        close-issue-message: 'This issue has been automatically closed since there has been no further activity after seven days and will be automatically locked in sixty days. Feel free to re-open this issue or you can create a follow-up issue'
+        close-pr-message: 'This pull request has been automatically closed since there has been no further activity after seven days. Feel free to re-open the pull request or you can create a new follow-up pull request.'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         days-before-stale: 90
         days-before-close: 7
         enable-statistics: 'true'
-  lock:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dessant/lock-threads@v4
-        with:
-          issue-inactive-days: '60'
-          pr-inactive-days: '60'
-          issue-lock-reason: ''
+  #lock:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: dessant/lock-threads@v4
+  #      with:
+  #        issue-inactive-days: '60'
+  #        pr-inactive-days: '60'
+  #        issue-lock-reason: ''

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,11 +26,3 @@ jobs:
         days-before-stale: 90
         days-before-close: 7
         enable-statistics: 'true'
-  #lock:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: dessant/lock-threads@v4
-  #      with:
-  #        issue-inactive-days: '60'
-  #        pr-inactive-days: '60'
-  #        issue-lock-reason: ''

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,10 +17,10 @@ jobs:
         exempt-issue-labels: 'keep'
         exempt-pr-labels: 'keep'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'There has not been any activity on this issue in the last ninety and will automatically close in seven days. Comment on this issue to prevent this issue from closing automatically.'
-        stale-pr-message: 'There has not been any activity on this pull request in the last ninety and will automatically close in seven days. Comment on this issue to prevent this pull request from closing automatically.'
-        close-issue-message: 'This issue has been automatically closed since there has been no further activity after seven days.'
-        close-pr-message: 'This pull request has been automatically closed since there has been no further activity after seven days.'
+        stale-issue-message: 'There has been no activity on this issue in the last ninety days and will automatically close in seven days. Leave a comment on this issue to prevent it from closing automatically.'
+        stale-pr-message: 'There has not been any activity on this pull request in the last ninety days and will automatically close in seven days. Leave a comment on this pull request to prevent it from closing automatically.'
+        close-issue-message: 'This issue has been automatically closed since there has been no further activity after seven days and will be automatically locked in sixty days. During that time feel free to re-open the issue or you can create a new follow-up issue afterwards.'
+        close-pr-message: 'This pull request has been automatically closed since there has been no further activity after seven days and will be automatically locked in sixty days. During that time feel free to re-open the pull request or you can create a new follow-up pull request afterwards.'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         days-before-stale: 90


### PR DESCRIPTION
I've created some issue templates based on my comments #62. I've created a template for apiable, documentation, feature request, general issues and bug report. I've also created a label called Needs Review so it's easier to see which issues you haven't looked at yet when viewing the issues list.

I've marked this PR as a draft so you can go through and review the templates first before merging this PR into the repo. You can go to [my repository](https://github.com/cloneofghosts/pirateweather/issues/new/choose) in order to test each one and offer feedback.